### PR TITLE
:bookmark_tabs: hacky fix for htmlBuilder.

### DIFF
--- a/lib/BlockContent/HtmlBuilder.php
+++ b/lib/BlockContent/HtmlBuilder.php
@@ -21,7 +21,7 @@ class HtmlBuilder
             return $this->escape($content);
         }
 
-        $nodes = isset($content['type']) ? [$content] : $content;
+        $nodes = isset($content['_type']) ? [$content] : $content;
         $html = '';
         foreach ($nodes as $node) {
             $children = [];
@@ -39,11 +39,11 @@ class HtmlBuilder
             $values = $node;
             $values['children'] = $children;
 
-            if (!isset($this->serializers[$node['type']])) {
-                throw new ConfigException('No serializer registered for node type "' . $node['type'] . '"');
+            if (!isset($this->serializers[$node['_type']])) {
+                throw new ConfigException('No serializer registered for node type "' . $node['_type'] . '"');
             }
 
-            $serializer = $this->serializers[$node['type']];
+            $serializer = $this->serializers[$node['_type']];
             $serialized = call_user_func($serializer, $values, $parent, $this);
             $html .= $serialized;
         }

--- a/lib/BlockContent/Serializers/DefaultBlock.php
+++ b/lib/BlockContent/Serializers/DefaultBlock.php
@@ -6,6 +6,7 @@ class DefaultBlock
     public function __invoke($block)
     {
         $tag = $block['style'] === 'normal' ? 'p' : $block['style'];
-        return '<' . $tag . '>' . implode('', $block['children']) . '</' . $tag . '>';
+        // return '<' . $tag . '>' . implode('', $block['children']) . '</' . $tag . '>';
+        return '<' . $tag . '>' . $block['spans'][0]['text'] . '</' . $tag . '>';
     }
 }


### PR DESCRIPTION
```
Notice: Undefined index: type
500 Internal Server Error - ContextErrorException
”
Stack Trace
in vendor/sanity/sanity-php/lib/BlockContent/HtmlBuilder.php at line 42   -
            $values = $node;
            $values['children'] = $children;
            if (!isset($this->serializers[$node['type']])) {
                throw new ConfigException('No serializer registered for node type "' . $node['type'] . '"');
            }
```

This was the error, I changed `type` to `_type`. That returned empty <p> tags.