### PR TITLE
Bump guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "test": "./vendor/bin/phpunit && ./vendor/bin/phpcs lib"
     },
     "require": {
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7",


### PR DESCRIPTION
The `"guzzlehttp/guzzle": "^6.2"` requirement led to a version conflict when I attempted to install the package in a Laravel 8 project.

```
Problem 1
    - sanity/sanity-php[dev-master, dev-dependencies] require guzzlehttp/guzzle ^6.2 -> found guzzlehttp/guzzle[6.2.0, ..., 6.5.x-dev] but it conflicts with your root composer.json require (^7.0.1).
    - Root composer.json requires sanity/sanity-php @dev -> satisfiable by sanity/sanity-php[dev-dependencies, dev-master].
```