### PR TITLE
fix: clientConfig undefined index

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -67,7 +67,7 @@ class Client
         $serializedParams = $params ? ParameterSerializer::serialize($params) : [];
         $queryParams = array_merge(['query' => $query], $serializedParams);
 
-        if (isset($this->clientConfig['perspective']) && $this->clientConfig['clientConfig'] !== 'raw') {
+        if (isset($this->clientConfig['perspective']) && $this->clientConfig['perspective'] !== 'raw') {
             $queryParams['perspective'] = $this->clientConfig['perspective'];
         }
 


### PR DESCRIPTION
- Fix a possible index mistake on the implementation use of Perspectives. Found it outputting a record to error.log, which is: undefined index clientConfig on line 70 of sanity-php/lib/Client.php