### PR TITLE
feat: Allow autoGenerateArrayKeys option when mutating

### DIFF
--- a/lib/Client.php
+++ b/lib/Client.php
@@ -528,6 +528,10 @@ class Client
             $query['visibility'] = $options['visibility'];
         }
 
+        if (isset($options['autoGenerateArrayKeys']) && $options['autoGenerateArrayKeys']) {
+            $query['autoGenerateArrayKeys'] = 'true';
+        }
+
         return $query;
     }
 


### PR DESCRIPTION
This brings parity with the JS client in allowing the use of the `autoGenerateArrayKeys` when mutating.  Without this, a unique `_key` field must be manually created for every item in an array.