### PR TITLE
fix: prevent deprecation warning in php ^8.1

### DIFF
--- a/lib/Patch.php
+++ b/lib/Patch.php
@@ -121,6 +121,7 @@ class Patch implements JsonSerializable
         );
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->serialize();

--- a/lib/Selection.php
+++ b/lib/Selection.php
@@ -23,6 +23,7 @@ class Selection implements JsonSerializable
      *
      * @return array
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->serialize();

--- a/lib/Transaction.php
+++ b/lib/Transaction.php
@@ -105,6 +105,7 @@ class Transaction implements JsonSerializable
         return $this->operations;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return $this->serialize();


### PR DESCRIPTION
### Description

Using this library in PHP ^8.1 causes this deprecation warning:
```
deprecated: 8192 :: Return type of Sanity\Transaction::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

This PR adds the mentioned annotation `#[\ReturnTypeWillChange]`, which silences the deprecation without breaking compatibility to older PHP-Versions by specifying the return type.
The annotation is seen as a comment by older PHP-Versions.

### What to review
`jsonSerialized` was annotated with `#[\ReturnTypeWillChange]` in these files:
`lib/Path.php`
`lib/Selection.php`
`lib/Transaction.php`

### Testing
No deprecation warning present after applying the patch.