### PR TITLE
Harden BlockContent::isTree() and add regression tests

### DIFF
--- a/lib/BlockContent.php
+++ b/lib/BlockContent.php
@@ -24,7 +24,13 @@ class BlockContent
 
     public static function isTree($tree)
     {
-        return !isset($tree['_type']) && !isset($tree[0]['_type']);
+        if (!is_array($tree)) return false;
+
+        if (isset($tree['_type'])) return false;
+
+        if (isset($tree[0]) && is_array($tree[0]) && isset($tree[0]['_type'])) return false;
+
+        return true;
     }
 
     public static function migrate($content, $options = [])

--- a/test/BlockContentTreeTest.php
+++ b/test/BlockContentTreeTest.php
@@ -497,4 +497,34 @@ class BlockContentTreeTest extends TestCase
         $actual = $treeBuilder($input);
         $this->assertEquals($expected, $actual);
     }
+
+    public function testIsTreeReturnsFalseForNonArray()
+    {
+        $this->assertFalse(BlockContent::isTree(null));
+        $this->assertFalse(BlockContent::isTree('string'));
+        $this->assertFalse(BlockContent::isTree(123));
+        $this->assertFalse(BlockContent::isTree((object)['a' => 1]));
+    }
+
+    public function testIsTreeReturnsFalseForBlockObjectShape()
+    {
+        $this->assertFalse(BlockContent::isTree(['_type' => 'block']));
+    }
+
+    public function testIsTreeReturnsFalseForArrayOfBlocks()
+    {
+        $this->assertFalse(BlockContent::isTree([['_type' => 'block']]));
+    }
+
+    public function testIsTreeReturnsTrueForTreeLikeStructure()
+    {
+        $this->assertTrue(BlockContent::isTree([
+            ['type' => 'block', 'content' => ['hello']]
+        ]));
+    }
+
+    public function testIsTreeHandlesEmptyArray()
+    {
+        $this->assertTrue(BlockContent::isTree([]));
+    }
 }


### PR DESCRIPTION

### Description
<!-- What changes are introduced? Why are these changes introduced? What issue(s) does this solve? (with link, if possible) -->

This PR hardens` BlockContent::isTree()` by adding defensive checks for non-array inputs.
This is because, former pattern of passing a non-array value could trigger PHP notices (`e.g. when accessing $tree['_type'] or $tree[0]`). The method now returns false for non-arrays and preserves the existing behaviour for block-shaped arrays and arrays of blocks.

This reduces noise for downstream consumers and makes the API safer when unexpected data structures are passed in.

### What to review
<!-- What steps should the reviewer take in order to review? What parts/flows of the application/packages/tooling is affected? -->

- Review the updated logic in BlockContent::isTree():
    - Non-array inputs return false
    - Arrays with ['_type' => ...] return false
    - Arrays whose first element is a block ([0]['_type']) return false
    - Otherwise return true

- Check that behaviour remains unchanged for valid tree inputs and existing block inputs.
- Confirm the added tests cover the regression scenario and key edge cases.

### Testing
<!-- Did you add sufficient testing for this change? If not, please explain how you tested this change and why it was not possible/practical for writing an automated test -->

- Added unit test coverage for isTree() handling:
- Non-array inputs (e.g. null, scalars) return false
- Block-shaped arrays and arrays of blocks return false
- Tree-like structures return true

local test results
<img width="671" height="283" alt="スクリーンショット 2026-01-01 16 54 25" src="https://github.com/user-attachments/assets/a454240a-78d0-42d5-92d5-32b74a66b8e7" />
